### PR TITLE
Feature/support 256 memory testing

### DIFF
--- a/aws-common/nodejs-perf-logger/handler.js
+++ b/aws-common/nodejs-perf-logger/handler.js
@@ -87,11 +87,12 @@ module.exports.logger = (event, context, callback) => {
       let successCount = 0;
       let failureCount = 0;
 
-      console.log(`${parsedPayload}`);
+      console.log(`Logger detected invoke of ${functionNameValue}`);
 
 
       parsedPayload.logEvents.forEach(function (eventPayload) {
         const metrics = usageMetrics(eventPayload, functionNameValue, functionVersionValue);
+        console.log(`metrics received for ${functionNameValue}`);
 
         // call the API to store data 
         // TODO - make this asynchronous call as we don't really care about the response too much.
@@ -100,7 +101,7 @@ module.exports.logger = (event, context, callback) => {
           process.env.POST_METRICS_URL + "/metrics",
           { json: metrics },
           function (error, response, body) {
-              console.log(`Body: ${body}, Repsonse: ${response}, Error: ${error}`);
+              console.log(`Body: ${body}, Response: ${response}, Error: ${error}`);
               if (!error && response.statusCode == 200) {
                   successCount++;
               }

--- a/aws-common/nodejs-perf-logger/serverless.yml
+++ b/aws-common/nodejs-perf-logger/serverless.yml
@@ -36,6 +36,10 @@ functions:
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-nodejs12x'
           filter: 'REPORT'                  
+      - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-nodejs12x'
+          filter: 'REPORT'                  
+
   logger-dotnet:
     handler: handler.logger
     events:
@@ -48,6 +52,10 @@ functions:
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-dotnet21'
           filter: 'REPORT'          
+      - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-dotnet21'
+          filter: 'REPORT'          
+
   logger-java:
     handler: handler.logger
     events:
@@ -60,6 +68,10 @@ functions:
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-java8'
           filter: 'REPORT'          
+      - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-java8'
+          filter: 'REPORT'          
+
   logger-python:
     handler: handler.logger
     events:
@@ -71,7 +83,11 @@ functions:
           filter: 'REPORT'
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-python36'
-          filter: 'REPORT'          
+          filter: 'REPORT' 
+      - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-python36'
+          filter: 'REPORT' 
+
   logger-go:
     handler: handler.logger
     events:
@@ -83,6 +99,9 @@ functions:
           filter: 'REPORT'     
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-go'
+          filter: 'REPORT'                  
+      - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-go'
           filter: 'REPORT'                  
 
 

--- a/aws-common/nodejs-perf-logger/serverless.yml
+++ b/aws-common/nodejs-perf-logger/serverless.yml
@@ -31,6 +31,9 @@ functions:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-empty-nodejs12x'
           filter: 'REPORT'   
       - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-256-empty-nodejs12x'
+          filter: 'REPORT'   
+      - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-nodejs12x'
           filter: 'REPORT'                  
   logger-dotnet:
@@ -38,6 +41,9 @@ functions:
     events:
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-empty-dotnet21'
+          filter: 'REPORT'
+      - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-256-empty-dotnet21'
           filter: 'REPORT'
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-dotnet21'
@@ -49,6 +55,9 @@ functions:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-empty-java8'
           filter: 'REPORT'
       - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-256-empty-java8'
+          filter: 'REPORT'
+      - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-java8'
           filter: 'REPORT'          
   logger-python:
@@ -58,6 +67,9 @@ functions:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-empty-python36'
           filter: 'REPORT'
       - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-256-empty-python36'
+          filter: 'REPORT'
+      - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-python36'
           filter: 'REPORT'          
   logger-go:
@@ -65,6 +77,9 @@ functions:
     events:
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-empty-go'
+          filter: 'REPORT'     
+      - cloudwatchLog:
+          logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-warm-256-empty-go'
           filter: 'REPORT'     
       - cloudwatchLog:
           logGroup: '/aws/lambda/aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-go'

--- a/aws-test/aws-burst-invoker/handler.py
+++ b/aws-test/aws-burst-invoker/handler.py
@@ -27,21 +27,21 @@ def burst_invoker(event, context):
             return
 
         try:
-            local_threads = []
-            for x in range(event['invokeCount']):
-                for y in event['targetFunctionName']:
-                    print('Target Function: ', y)
-                # t = myThread(event['targetFunctionName'])
-                # local_threads.append(t)
-                # threads.append(t)
+            for functionToInvoke in event['targetFunctionName']:
+                local_threads = []
+                for x in range(event['invokeCount']):
+                    #print('Target Function: ', functionToInvoke)
+                    t = myThread(functionToInvoke)
+                    local_threads.append(t)
+                    threads.append(t)
 
-            # start all threads
-            for thread in local_threads:
-                thread.start()
+                # start all threads
+                for thread in local_threads:
+                    thread.start()
 
-            # make sure that all threads have finished
-            for thread in threads:
-                thread.join()
+                # make sure that all threads have finished
+                for thread in threads:
+                    thread.join()
         except Exception as e:
             print("Threading error: %s" % e)  
 

--- a/aws-test/aws-burst-invoker/handler.py
+++ b/aws-test/aws-burst-invoker/handler.py
@@ -19,7 +19,8 @@ class myThread(Thread):
 def burst_invoker(event, context):
     try:
         print('Event Count: ', event['invokeCount'])
-        print('Event Target: ', event['targetFunctionName'])
+        for y in event['targetFunctionName']:
+            print(f"Event Target: {y}")
 
         # putting in a hardcoded limit for safety to ensure we don't go wild calling lambdas
         if event['invokeCount'] > 10:
@@ -28,9 +29,11 @@ def burst_invoker(event, context):
         try:
             local_threads = []
             for x in range(event['invokeCount']):
-                t = myThread(event['targetFunctionName'])
-                local_threads.append(t)
-                threads.append(t)
+                for y in event['targetFunctionName']:
+                    print('Target Function: ', y)
+                # t = myThread(event['targetFunctionName'])
+                # local_threads.append(t)
+                # threads.append(t)
 
             # start all threads
             for thread in local_threads:
@@ -40,7 +43,7 @@ def burst_invoker(event, context):
             for thread in threads:
                 thread.join()
         except Exception as e:
-            print("Generic error: %s" % e)  
+            print("Threading error: %s" % e)  
 
         print('done')        
     except Exception as e:

--- a/aws-test/serverless.yml
+++ b/aws-test/serverless.yml
@@ -18,9 +18,9 @@ provider:
 custom:
   # you can use rate() or cron() syntax
   coldStartInterval: rate(60 minutes) # minutes => 1 hour 
-  coldStartBatchSize: 3 # e.g. => 6 every 60 minutes => 6 per hour
+  coldStartBatchSize: 3 # e.g. if 3 every 60 minutes => 3 per hour
   coldStartBatchMemory: 512
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: rate(2 minutes) # cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
 
 # package (e.g. .net zip) is specified per function rather than centrally as some don't need a package
 package:
@@ -148,24 +148,37 @@ functions:
   # begin cold-start test functions. No events - they're triggered by the batch cold start schedulers below.      
   aws-cold-empty-dotnet21:
     <<: *dotnet21-param
+  aws-cold-256-empty-dotnet21:
+    <<: *dotnet21-param
+    memorySize: 256
 
   aws-cold-empty-go:
     <<: *go1x-param
-
   aws-cold-256-empty-go:
     <<: *go1x-param
     memorySize: 256
 
   aws-cold-empty-java8:
     <<: *java8-param
+  aws-cold-256-empty-java8:
+    <<: *java8-param
+    memorySize: 256
 
   aws-cold-empty-nodejs12x:
     runtime: nodejs12.x
     handler: aws-service-nodejs12x/handler.emptytestnodejs12x
+  aws-cold-256-empty-nodejs12x:
+    runtime: nodejs12.x
+    handler: aws-service-nodejs12x/handler.emptytestnodejs12x
+    memorySize: 256
 
   aws-cold-empty-python36:
     runtime: python3.6
     handler: aws-service-python36/handler.awsemptypython36
+  aws-cold-256-empty-python36:
+    runtime: python3.6
+    handler: aws-service-python36/handler.awsemptypython36
+    memorySize: 256
 
   # begin cold-start-scheduler functions
   awspython36-coldstart:
@@ -177,7 +190,9 @@ functions:
           enabled: false
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
-            targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-python36
+            targetFunctionName: 
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-python36
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-python36
 
   awsnodejs12x-coldstart:
     <<: *coldstart-param
@@ -188,7 +203,9 @@ functions:
           enabled: false
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
-            targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-nodejs12x
+            targetFunctionName: 
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-nodejs12x
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-nodejs12x
 
   awsjava8-coldstart:
     <<: *coldstart-param
@@ -199,7 +216,9 @@ functions:
           enabled: false
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
-            targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-java8
+            targetFunctionName: 
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-java8
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-java8
 
   awsgo-coldstart:
     <<: *coldstart-param
@@ -223,6 +242,8 @@ functions:
           enabled: false
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
-            targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-dotnet21
+            targetFunctionName: 
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-dotnet21
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-dotnet21
 
 

--- a/aws-test/serverless.yml
+++ b/aws-test/serverless.yml
@@ -48,6 +48,11 @@ go1x-param-reuse: &go1x-param
     include:
       - ./aws-service-go/bin/**
 
+coldstart-param-reuse: &coldstart-param
+  runtime: python3.7
+  handler: aws-burst-invoker/handler.burst_invoker
+  memorySize: ${self:custom.coldStartBatchMemory}
+
 # individual function definitions
 functions:
   # begin warm-start test functions
@@ -142,34 +147,25 @@ functions:
 
   # begin cold-start test functions. No events - they're triggered by the batch cold start schedulers below.      
   aws-cold-empty-dotnet21:
-    runtime: dotnetcore2.1
-    handler: CsharpHandlers::ServerlessPerformanceFramework.Handler::EmptyTestDotNetCore2
-    package:
-      artifact: aws-service-dotnetcore2/bin/release/netcoreapp2.1/deploy-package.zip
+    <<: *dotnet21-param
+
   aws-cold-empty-go:
-    runtime: go1.x
-    handler: aws-service-go/bin/go-empty-function
-    package:
-      exclude:
-        - ./aws-service-go/**
-      include:
-        - ./aws-service-go/bin/**
+    <<: *go1x-param
+
   aws-cold-empty-java8:
-    runtime: java8
-    handler: com.learnspree.EmptyJava8Handler
-    package:
-      artifact: aws-service-java8/target/awsjava8empty-${self:provider.stage}.jar
+    <<: *java8-param
+
   aws-cold-empty-nodejs12x:
     runtime: nodejs12.x
     handler: aws-service-nodejs12x/handler.emptytestnodejs12x
+
   aws-cold-empty-python36:
     runtime: python3.6
     handler: aws-service-python36/handler.awsemptypython36
+
   # begin cold-start-scheduler functions
   awspython36-coldstart:
-    runtime: python3.7
-    handler: aws-burst-invoker/handler.burst_invoker
-    memorySize: ${self:custom.coldStartBatchMemory}
+    <<: *coldstart-param
     events:
       - schedule: 
           rate: ${self:custom.coldStartInterval}
@@ -178,10 +174,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-python36
+
   awsnodejs12x-coldstart:
-    runtime: python3.7
-    handler: aws-burst-invoker/handler.burst_invoker
-    memorySize: ${self:custom.coldStartBatchMemory}
+    <<: *coldstart-param
     events:
       - schedule: 
           rate: ${self:custom.coldStartInterval}
@@ -190,10 +185,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-nodejs12x
+
   awsjava8-coldstart:
-    runtime: python3.7
-    handler: aws-burst-invoker/handler.burst_invoker
-    memorySize: ${self:custom.coldStartBatchMemory}
+    <<: *coldstart-param
     events:
       - schedule: 
           rate: ${self:custom.coldStartInterval}
@@ -202,29 +196,27 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-java8
+
   awsgo-coldstart:
-      runtime: python3.7
-      handler: aws-burst-invoker/handler.burst_invoker
-      memorySize: ${self:custom.coldStartBatchMemory}
-      events:
-        - schedule: 
-            rate: ${self:custom.coldStartInterval}
-            name: coldstart-go-${self:provider.stage}-hourly-burst
-            enabled: false
-            input:
-              invokeCount: ${self:custom.coldStartBatchSize}
-              targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-go
+    <<: *coldstart-param
+    events:
+      - schedule: 
+          rate: ${self:custom.coldStartInterval}
+          name: coldstart-go-${self:provider.stage}-hourly-burst
+          enabled: false
+          input:
+            invokeCount: ${self:custom.coldStartBatchSize}
+            targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-go
+
   awsdotnet2-coldstart:
-        runtime: python3.7
-        handler: aws-burst-invoker/handler.burst_invoker
-        memorySize: ${self:custom.coldStartBatchMemory}
-        events:
-          - schedule: 
-              rate: ${self:custom.coldStartInterval}
-              name: coldstart-dotnet21-${self:provider.stage}-hourly-burst
-              enabled: false
-              input:
-                invokeCount: ${self:custom.coldStartBatchSize}
-                targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-dotnet21
+    <<: *coldstart-param
+    events:
+      - schedule: 
+          rate: ${self:custom.coldStartInterval}
+          name: coldstart-dotnet21-${self:provider.stage}-hourly-burst
+          enabled: false
+          input:
+            invokeCount: ${self:custom.coldStartBatchSize}
+            targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-dotnet21
 
 

--- a/aws-test/serverless.yml
+++ b/aws-test/serverless.yml
@@ -26,42 +26,82 @@ custom:
 package:
   individually: true 
 
+# function parameters declared for re-use
+dotnet21-param-reuse: &dotnet21-param
+  runtime: dotnetcore2.1
+  handler: CsharpHandlers::ServerlessPerformanceFramework.Handler::EmptyTestDotNetCore2
+  package:
+    artifact: aws-service-dotnetcore2/bin/release/netcoreapp2.1/deploy-package.zip
+
+java8-param-reuse: &java8-param
+  runtime: java8
+  handler: com.learnspree.EmptyJava8Handler
+  package:
+    artifact: aws-service-java8/target/awsjava8empty-${self:provider.stage}.jar
+
+go1x-param-reuse: &go1x-param
+  runtime: go1.x
+  handler: aws-service-go/bin/go-empty-function
+  package:
+    exclude:
+      - ./aws-service-go/**
+    include:
+      - ./aws-service-go/bin/**
+
 # individual function definitions
 functions:
   # begin warm-start test functions
   aws-warm-empty-dotnet21:
-    runtime: dotnetcore2.1
-    handler: CsharpHandlers::ServerlessPerformanceFramework.Handler::EmptyTestDotNetCore2
-    package:
-      artifact: aws-service-dotnetcore2/bin/release/netcoreapp2.1/deploy-package.zip
+    <<: *dotnet21-param
     events:
-      - schedule: 
-          rate: ${self:custom.warmStartInterval}
-          name: warmstart-dotnet21-${self:provider.stage}-minute
-          enabled: false
+    - schedule: 
+        rate: ${self:custom.warmStartInterval}
+        name: warmstart-dotnet21-${self:provider.stage}-minute
+        enabled: false
+      
+  aws-warm-256-empty-dotnet21:
+    <<: *dotnet21-param
+    memorySize: 256
+    events:
+    - schedule: 
+        rate: ${self:custom.warmStartInterval}
+        name: warmstart-256-dotnet21-${self:provider.stage}-minute
+        enabled: false
+
   aws-warm-empty-go:
-    runtime: go1.x
-    handler: aws-service-go/bin/go-empty-function
-    package:
-      exclude:
-        - ./aws-service-go/**
-      include:
-        - ./aws-service-go/bin/**
+    <<: *go1x-param
     events:
       - schedule: 
           rate: ${self:custom.warmStartInterval}
           name: warmstart-go-${self:provider.stage}-minute
           enabled: false
+
+  aws-warm-256-empty-go:
+    <<: *go1x-param
+    memorySize: 256
+    events:
+      - schedule: 
+          rate: ${self:custom.warmStartInterval}
+          name: warmstart-256-go-${self:provider.stage}-minute
+          enabled: false          
+
   aws-warm-empty-java8:
-    runtime: java8
-    handler: com.learnspree.EmptyJava8Handler
-    package:
-      artifact: aws-service-java8/target/awsjava8empty-${self:provider.stage}.jar
+    <<: *java8-param
     events:
       - schedule: 
           rate: ${self:custom.warmStartInterval}
           name: warmstart-java8-${self:provider.stage}-minute
           enabled: false
+
+  aws-warm-256-empty-java8:
+    <<: *java8-param
+    memorySize: 256
+    events:
+      - schedule: 
+          rate: ${self:custom.warmStartInterval}
+          name: warmstart-256-java8-${self:provider.stage}-minute
+          enabled: false          
+
   aws-warm-empty-nodejs12x:
     runtime: nodejs12.x
     handler: aws-service-nodejs12x/handler.emptytestnodejs12x
@@ -69,7 +109,18 @@ functions:
       - schedule: 
           rate: ${self:custom.warmStartInterval}
           name: warmstart-nodejs12x-${self:provider.stage}-minute
-          enabled: false    
+          enabled: false   
+
+  aws-warm-256-empty-nodejs12x:
+    runtime: nodejs12.x
+    handler: aws-service-nodejs12x/handler.emptytestnodejs12x
+    memorySize: 256
+    events:
+      - schedule: 
+          rate: ${self:custom.warmStartInterval}
+          name: warmstart-256-nodejs12x-${self:provider.stage}-minute
+          enabled: false            
+
   aws-warm-empty-python36:
     runtime: python3.6
     handler: aws-service-6/handler.awsemptypython3
@@ -78,6 +129,17 @@ functions:
           rate: ${self:custom.warmStartInterval}
           name: warmstart-python36-${self:provider.stage}-minute
           enabled: false
+
+  aws-warm-256-empty-python36:
+    runtime: python3.6
+    handler: aws-service-6/handler.awsemptypython3
+    memorySize: 256
+    events:
+      - schedule: 
+          rate: ${self:custom.warmStartInterval}
+          name: warmstart-256-python36-${self:provider.stage}-minute
+          enabled: false          
+
   # begin cold-start test functions. No events - they're triggered by the batch cold start schedulers below.      
   aws-cold-empty-dotnet21:
     runtime: dotnetcore2.1

--- a/aws-test/serverless.yml
+++ b/aws-test/serverless.yml
@@ -152,6 +152,10 @@ functions:
   aws-cold-empty-go:
     <<: *go1x-param
 
+  aws-cold-256-empty-go:
+    <<: *go1x-param
+    memorySize: 256
+
   aws-cold-empty-java8:
     <<: *java8-param
 
@@ -206,7 +210,9 @@ functions:
           enabled: false
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
-            targetFunctionName: aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-go
+            targetFunctionName: 
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-empty-go
+              - aws-empty-test-functions-${self:provider.stage}-aws-cold-256-empty-go
 
   awsdotnet2-coldstart:
     <<: *coldstart-param

--- a/aws-test/serverless.yml
+++ b/aws-test/serverless.yml
@@ -20,7 +20,7 @@ custom:
   coldStartInterval: rate(60 minutes) # minutes => 1 hour 
   coldStartBatchSize: 3 # e.g. if 3 every 60 minutes => 3 per hour
   coldStartBatchMemory: 512
-  warmStartInterval: rate(2 minutes) # cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
 
 # package (e.g. .net zip) is specified per function rather than centrally as some don't need a package
 package:

--- a/bin/disable-all-rules.sh
+++ b/bin/disable-all-rules.sh
@@ -28,17 +28,20 @@ if [[ $environment != "dev" ]] && [[ $environment != "prod" ]]; then
     helpFunction
 fi
 
+# Cold Start - covers all memory allocations
+aws events disable-rule --name coldstart-python36-$environment-hourly-burst 
+aws events disable-rule --name coldstart-nodejs12x-$environment-hourly-burst 
+aws events disable-rule --name coldstart-java8-$environment-hourly-burst 
+aws events disable-rule --name coldstart-go-$environment-hourly-burst 
+aws events disable-rule --name coldstart-dotnet21-$environment-hourly-burst 
+
+# Warm Start
 # 128 MB
 aws events disable-rule --name warmstart-nodejs12x-$environment-minute 
 aws events disable-rule --name warmstart-java8-$environment-minute 
 aws events disable-rule --name warmstart-dotnet21-$environment-minute 
 aws events disable-rule --name warmstart-python36-$environment-minute 
 aws events disable-rule --name warmstart-go-$environment-minute 
-aws events disable-rule --name coldstart-python36-$environment-hourly-burst 
-aws events disable-rule --name coldstart-nodejs12x-$environment-hourly-burst 
-aws events disable-rule --name coldstart-java8-$environment-hourly-burst 
-aws events disable-rule --name coldstart-go-$environment-hourly-burst 
-aws events disable-rule --name coldstart-dotnet21-$environment-hourly-burst 
 
 # 256 MB
 aws events disable-rule --name warmstart-256-nodejs12x-$environment-minute 

--- a/bin/disable-all-rules.sh
+++ b/bin/disable-all-rules.sh
@@ -28,6 +28,7 @@ if [[ $environment != "dev" ]] && [[ $environment != "prod" ]]; then
     helpFunction
 fi
 
+# 128 MB
 aws events disable-rule --name warmstart-nodejs12x-$environment-minute 
 aws events disable-rule --name warmstart-java8-$environment-minute 
 aws events disable-rule --name warmstart-dotnet21-$environment-minute 
@@ -38,3 +39,10 @@ aws events disable-rule --name coldstart-nodejs12x-$environment-hourly-burst
 aws events disable-rule --name coldstart-java8-$environment-hourly-burst 
 aws events disable-rule --name coldstart-go-$environment-hourly-burst 
 aws events disable-rule --name coldstart-dotnet21-$environment-hourly-burst 
+
+# 256 MB
+aws events disable-rule --name warmstart-256-nodejs12x-$environment-minute 
+aws events disable-rule --name warmstart-256-java8-$environment-minute 
+aws events disable-rule --name warmstart-256-dotnet21-$environment-minute 
+aws events disable-rule --name warmstart-256-python36-$environment-minute 
+aws events disable-rule --name warmstart-256-go-$environment-minute 

--- a/bin/enable-all-rules.sh
+++ b/bin/enable-all-rules.sh
@@ -28,6 +28,7 @@ if [[ $environment != "dev" ]] && [[ $environment != "prod" ]]; then
     helpFunction
 fi
 
+# 128 MB 
 aws events enable-rule --name warmstart-nodejs12x-$environment-minute 
 aws events enable-rule --name warmstart-java8-$environment-minute 
 aws events enable-rule --name warmstart-dotnet21-$environment-minute 
@@ -38,3 +39,10 @@ aws events enable-rule --name coldstart-nodejs12x-$environment-hourly-burst
 aws events enable-rule --name coldstart-java8-$environment-hourly-burst 
 aws events enable-rule --name coldstart-go-$environment-hourly-burst 
 aws events enable-rule --name coldstart-dotnet21-$environment-hourly-burst 
+
+# 256 MB 
+aws events enable-rule --name warmstart-256-nodejs12x-$environment-minute 
+aws events enable-rule --name warmstart-256-java8-$environment-minute 
+aws events enable-rule --name warmstart-256-dotnet21-$environment-minute 
+aws events enable-rule --name warmstart-256-python36-$environment-minute 
+aws events enable-rule --name warmstart-256-go-$environment-minute 

--- a/bin/enable-all-rules.sh
+++ b/bin/enable-all-rules.sh
@@ -28,17 +28,20 @@ if [[ $environment != "dev" ]] && [[ $environment != "prod" ]]; then
     helpFunction
 fi
 
+# Cold Start - covers all memory allocations
+aws events enable-rule --name coldstart-python36-$environment-hourly-burst 
+aws events enable-rule --name coldstart-nodejs12x-$environment-hourly-burst 
+aws events enable-rule --name coldstart-java8-$environment-hourly-burst 
+aws events enable-rule --name coldstart-go-$environment-hourly-burst 
+aws events enable-rule --name coldstart-dotnet21-$environment-hourly-burst 
+
+# Warm Start
 # 128 MB 
 aws events enable-rule --name warmstart-nodejs12x-$environment-minute 
 aws events enable-rule --name warmstart-java8-$environment-minute 
 aws events enable-rule --name warmstart-dotnet21-$environment-minute 
 aws events enable-rule --name warmstart-python36-$environment-minute 
 aws events enable-rule --name warmstart-go-$environment-minute 
-aws events enable-rule --name coldstart-python36-$environment-hourly-burst 
-aws events enable-rule --name coldstart-nodejs12x-$environment-hourly-burst 
-aws events enable-rule --name coldstart-java8-$environment-hourly-burst 
-aws events enable-rule --name coldstart-go-$environment-hourly-burst 
-aws events enable-rule --name coldstart-dotnet21-$environment-hourly-burst 
 
 # 256 MB 
 aws events enable-rule --name warmstart-256-nodejs12x-$environment-minute 


### PR DESCRIPTION
Adds support for 256MB memory testing in addition to the default 128MB for all runtimes in cold and warm start scenarios.

closes #43 