### PR TITLE
Updating warm-start test schedule to be a 15-minute series ever 4 hours

### DIFF
--- a/aws-test/aws-service-dotnetcore2/serverless.yml
+++ b/aws-test/aws-service-dotnetcore2/serverless.yml
@@ -11,7 +11,7 @@ provider:
   versionFunctions: true # Optional function versioning
 
 custom:
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(0 0-15 0/4 ? * * *) # every 4 hours we do a 15-minute series starting at 0 past the hour => 15 per hour, 6 times a day
 
 # package (e.g. .net zip) is specified per function rather than centrally as some don't need a package
 package:

--- a/aws-test/aws-service-go/serverless.yml
+++ b/aws-test/aws-service-go/serverless.yml
@@ -11,7 +11,7 @@ provider:
   versionFunctions: true # Optional function versioning
 
 custom:
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(0 0-15 0/4 ? * * *) # every 4 hours we do a 15-minute series starting at 0 past the hour => 15 per hour, 6 times a day
 
 # package (e.g. .net zip) is specified per function rather than centrally as some don't need a package
 package:

--- a/aws-test/aws-service-java/serverless.yml
+++ b/aws-test/aws-service-java/serverless.yml
@@ -12,7 +12,7 @@ provider:
 
 custom:
   # you can use rate() or cron() syntax
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(0 0-15 0/4 ? * * *) # every 4 hours we do a 15-minute series starting at 0 past the hour => 15 per hour, 6 times a day
 
 # package (e.g. .net zip) is specified per function rather than centrally as some don't need a package
 package:

--- a/aws-test/aws-service-java11/serverless.yml
+++ b/aws-test/aws-service-java11/serverless.yml
@@ -11,7 +11,7 @@ provider:
   versionFunctions: true # Optional function versioning
 
 custom:
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(0 0-15 0/4 ? * * *) # every 4 hours we do a 15-minute series starting at 0 past the hour => 15 per hour, 6 times a day
 
 # package (e.g. .net zip) is specified per function rather than centrally as some don't need a package
 package:

--- a/aws-test/aws-service-nodejs/serverless.yml
+++ b/aws-test/aws-service-nodejs/serverless.yml
@@ -12,7 +12,7 @@ provider:
 
 custom:
   # you can use rate() or cron() syntax
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(0 0-15 0/4 ? * * *) # every 4 hours we do a 15-minute series starting at 0 past the hour => 15 per hour, 6 times a day
 
 # individual function definitions
 functions:

--- a/aws-test/aws-service-python/serverless.yml
+++ b/aws-test/aws-service-python/serverless.yml
@@ -12,7 +12,7 @@ provider:
 
 custom:
   # you can use rate() or cron() syntax
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(0 0-15 0/4 ? * * *) # every 4 hours we do a 15-minute series starting at 0 past the hour => 15 per hour, 6 times a day
 
 # individual function definitions
 functions:

--- a/aws-test/aws-service-ruby/serverless.yml
+++ b/aws-test/aws-service-ruby/serverless.yml
@@ -12,7 +12,7 @@ provider:
   versionFunctions: true # Optional function versioning
 
 custom:
-  warmStartInterval: cron(56/1 * * * ? *) # every 1 minute starting at 56 past the hour => 4 per hour (but 1st will likely be cold)
+  warmStartInterval: cron(0 0-15 0/4 ? * * *) # every 4 hours we do a 15-minute series starting at 0 past the hour => 15 per hour, 6 times a day
 
 # individual function definitions
 functions:


### PR DESCRIPTION
Every 4 hours - rather than 3 minutes every hour to give smoother results more tolerant of spikes