### PR TITLE
Feature/shorten lambda function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Each target function will essentially be setup with two cloud-watch-batch based 
             enabled: false
             input:
                 invokeCount: ${self:custom.coldStartBatchSize}
-                targetFunctionName: aws-empty-test-functions-dev-awsnodejs12x                 
+                targetFunctionName: aws-test-dev-awsnodejs12x                 
 ```
 
 View "/aws-common/serverless.yml" to view the list of source cloud-watch-logs that are a trigger to measure performance of each target function deployed above. Example below for the node 12.x function:
@@ -158,7 +158,7 @@ View "/aws-common/serverless.yml" to view the list of source cloud-watch-logs th
 ```bash
     events:
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-dev-awsnodejs12x'
+          logGroup: '/aws/lambda/aws-test-dev-awsnodejs12x'
           filter: 'REPORT'
 ```
 

--- a/aws-common/serverless.yml
+++ b/aws-common/serverless.yml
@@ -28,202 +28,202 @@ functions:
     handler: handler.logger
     events:
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-warm-empty-nodejs12x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-warm-empty-nodejs12x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-empty-nodejs12x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-cold-empty-nodejs12x'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-warm-256-empty-nodejs12x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-warm-256-empty-nodejs12x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs12x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs12x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-warm-512-empty-nodejs12x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-warm-512-empty-nodejs12x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs12x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs12x'
           filter: 'REPORT'     
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-warm-empty-nodejs10x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-warm-empty-nodejs10x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-empty-nodejs10x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-cold-empty-nodejs10x'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-warm-256-empty-nodejs10x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-warm-256-empty-nodejs10x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs10x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs10x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-warm-512-empty-nodejs10x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-warm-512-empty-nodejs10x'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs10x'
+          logGroup: '/aws/lambda/aws-test-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs10x'
           filter: 'REPORT'                                 
 
   logger-dotnet:
     handler: handler.logger
     events:
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-dotnet-${self:provider.stage}-aws-warm-empty-dotnet21'
+          logGroup: '/aws/lambda/aws-test-dotnet-${self:provider.stage}-aws-warm-empty-dotnet21'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-dotnet-${self:provider.stage}-aws-cold-empty-dotnet21'
+          logGroup: '/aws/lambda/aws-test-dotnet-${self:provider.stage}-aws-cold-empty-dotnet21'
           filter: 'REPORT'           
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-dotnet-${self:provider.stage}-aws-warm-256-empty-dotnet21'
+          logGroup: '/aws/lambda/aws-test-dotnet-${self:provider.stage}-aws-warm-256-empty-dotnet21'
           filter: 'REPORT'         
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-dotnet-${self:provider.stage}-aws-cold-256-empty-dotnet21'
+          logGroup: '/aws/lambda/aws-test-dotnet-${self:provider.stage}-aws-cold-256-empty-dotnet21'
           filter: 'REPORT'          
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-dotnet-${self:provider.stage}-aws-warm-512-empty-dotnet21'
+          logGroup: '/aws/lambda/aws-test-dotnet-${self:provider.stage}-aws-warm-512-empty-dotnet21'
           filter: 'REPORT'         
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-dotnet-${self:provider.stage}-aws-cold-512-empty-dotnet21'
+          logGroup: '/aws/lambda/aws-test-dotnet-${self:provider.stage}-aws-cold-512-empty-dotnet21'
           filter: 'REPORT'   
 
   logger-java:
     handler: handler.logger
     events:
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java-${self:provider.stage}-aws-warm-empty-java8'
+          logGroup: '/aws/lambda/aws-test-java-${self:provider.stage}-aws-warm-empty-java8'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java-${self:provider.stage}-aws-cold-empty-java8'
+          logGroup: '/aws/lambda/aws-test-java-${self:provider.stage}-aws-cold-empty-java8'
           filter: 'REPORT'          
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java-${self:provider.stage}-aws-warm-256-empty-java8'
+          logGroup: '/aws/lambda/aws-test-java-${self:provider.stage}-aws-warm-256-empty-java8'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java-${self:provider.stage}-aws-cold-256-empty-java8'
+          logGroup: '/aws/lambda/aws-test-java-${self:provider.stage}-aws-cold-256-empty-java8'
           filter: 'REPORT'          
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java-${self:provider.stage}-aws-warm-512-empty-java8'
+          logGroup: '/aws/lambda/aws-test-java-${self:provider.stage}-aws-warm-512-empty-java8'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java-${self:provider.stage}-aws-cold-512-empty-java8'
+          logGroup: '/aws/lambda/aws-test-java-${self:provider.stage}-aws-cold-512-empty-java8'
           filter: 'REPORT'   
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java11-${self:provider.stage}-aws-warm-empty-java11'
+          logGroup: '/aws/lambda/aws-test-java11-${self:provider.stage}-aws-warm-empty-java11'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java11-${self:provider.stage}-aws-cold-empty-java11'
+          logGroup: '/aws/lambda/aws-test-java11-${self:provider.stage}-aws-cold-empty-java11'
           filter: 'REPORT'          
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java11-${self:provider.stage}-aws-warm-256-empty-java11'
+          logGroup: '/aws/lambda/aws-test-java11-${self:provider.stage}-aws-warm-256-empty-java11'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java11-${self:provider.stage}-aws-cold-256-empty-java11'
+          logGroup: '/aws/lambda/aws-test-java11-${self:provider.stage}-aws-cold-256-empty-java11'
           filter: 'REPORT'          
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java11-${self:provider.stage}-aws-warm-512-empty-java11'
+          logGroup: '/aws/lambda/aws-test-java11-${self:provider.stage}-aws-warm-512-empty-java11'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-java11-${self:provider.stage}-aws-cold-512-empty-java11'
+          logGroup: '/aws/lambda/aws-test-java11-${self:provider.stage}-aws-cold-512-empty-java11'
           filter: 'REPORT' 
 
   logger-python:
     handler: handler.logger
     events:
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-warm-empty-python36'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-warm-empty-python36'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-cold-empty-python36'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-cold-empty-python36'
           filter: 'REPORT' 
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-warm-256-empty-python36'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-warm-256-empty-python36'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-cold-256-empty-python36'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-cold-256-empty-python36'
           filter: 'REPORT' 
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-warm-512-empty-python36'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-warm-512-empty-python36'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-cold-512-empty-python36'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-cold-512-empty-python36'
           filter: 'REPORT' 
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-warm-empty-python38'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-warm-empty-python38'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-cold-empty-python38'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-cold-empty-python38'
           filter: 'REPORT' 
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-warm-256-empty-python38'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-warm-256-empty-python38'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-cold-256-empty-python38'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-cold-256-empty-python38'
           filter: 'REPORT' 
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-warm-512-empty-python38'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-warm-512-empty-python38'
           filter: 'REPORT'
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-python-${self:provider.stage}-aws-cold-512-empty-python38'
+          logGroup: '/aws/lambda/aws-test-python-${self:provider.stage}-aws-cold-512-empty-python38'
           filter: 'REPORT'           
 
   logger-go:
     handler: handler.logger
     events:
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-go-${self:provider.stage}-aws-warm-empty-go'
+          logGroup: '/aws/lambda/aws-test-go-${self:provider.stage}-aws-warm-empty-go'
           filter: 'REPORT'  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-go-${self:provider.stage}-aws-cold-empty-go'
+          logGroup: '/aws/lambda/aws-test-go-${self:provider.stage}-aws-cold-empty-go'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-go-${self:provider.stage}-aws-warm-256-empty-go'
+          logGroup: '/aws/lambda/aws-test-go-${self:provider.stage}-aws-warm-256-empty-go'
           filter: 'REPORT'     
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-go-${self:provider.stage}-aws-cold-256-empty-go'
+          logGroup: '/aws/lambda/aws-test-go-${self:provider.stage}-aws-cold-256-empty-go'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-go-${self:provider.stage}-aws-warm-512-empty-go'
+          logGroup: '/aws/lambda/aws-test-go-${self:provider.stage}-aws-warm-512-empty-go'
           filter: 'REPORT'     
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-go-${self:provider.stage}-aws-cold-512-empty-go'
+          logGroup: '/aws/lambda/aws-test-go-${self:provider.stage}-aws-cold-512-empty-go'
           filter: 'REPORT' 
           
   logger-ruby:
     handler: handler.logger
     events:
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-warm-empty-ruby25'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-warm-empty-ruby25'
           filter: 'REPORT'  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-empty-ruby25'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-cold-empty-ruby25'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-warm-256-empty-ruby25'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-warm-256-empty-ruby25'
           filter: 'REPORT'     
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-256-empty-ruby25'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-cold-256-empty-ruby25'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-warm-512-empty-ruby25'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-warm-512-empty-ruby25'
           filter: 'REPORT'     
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-512-empty-ruby25'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-cold-512-empty-ruby25'
           filter: 'REPORT'            
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-warm-empty-ruby27'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-warm-empty-ruby27'
           filter: 'REPORT'  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-empty-ruby27'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-cold-empty-ruby27'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-warm-256-empty-ruby27'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-warm-256-empty-ruby27'
           filter: 'REPORT'     
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-256-empty-ruby27'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-cold-256-empty-ruby27'
           filter: 'REPORT'                  
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-warm-512-empty-ruby27'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-warm-512-empty-ruby27'
           filter: 'REPORT'     
       - cloudwatchLog:
-          logGroup: '/aws/lambda/aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-512-empty-ruby27'
+          logGroup: '/aws/lambda/aws-test-ruby-${self:provider.stage}-aws-cold-512-empty-ruby27'
           filter: 'REPORT' 

--- a/aws-test/aws-burst-invoker/serverless.yml
+++ b/aws-test/aws-burst-invoker/serverless.yml
@@ -19,7 +19,7 @@ provider:
     - Effect: Allow
       Action:
         - lambda:InvokeFunction
-      Resource: "arn:aws:lambda:${self:provider.region}:*:function:aws-empty-test*" 
+      Resource: "arn:aws:lambda:${self:provider.region}:*:function:aws-test*" 
 
 coldstart-param-reuse: &coldstart-param
   runtime: python3.8

--- a/aws-test/aws-burst-invoker/serverless.yml
+++ b/aws-test/aws-burst-invoker/serverless.yml
@@ -1,6 +1,6 @@
 # Config file for aws empty-test functions
 #
-service: aws-empty-test-functions-cold-burst
+service: aws-test-cold-burst
 
 custom:
   # you can use rate() or cron() syntax
@@ -38,9 +38,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-go-${self:provider.stage}-aws-cold-empty-go
-              - aws-empty-test-functions-go-${self:provider.stage}-aws-cold-256-empty-go
-              - aws-empty-test-functions-go-${self:provider.stage}-aws-cold-512-empty-go
+              - aws-test-go-${self:provider.stage}-aws-cold-empty-go
+              - aws-test-go-${self:provider.stage}-aws-cold-256-empty-go
+              - aws-test-go-${self:provider.stage}-aws-cold-512-empty-go
 
   awsdotnet2-coldstart:
     <<: *coldstart-param
@@ -52,9 +52,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-dotnet-${self:provider.stage}-aws-cold-empty-dotnet21
-              - aws-empty-test-functions-dotnet-${self:provider.stage}-aws-cold-256-empty-dotnet21
-              - aws-empty-test-functions-dotnet-${self:provider.stage}-aws-cold-512-empty-dotnet21
+              - aws-test-dotnet-${self:provider.stage}-aws-cold-empty-dotnet21
+              - aws-test-dotnet-${self:provider.stage}-aws-cold-256-empty-dotnet21
+              - aws-test-dotnet-${self:provider.stage}-aws-cold-512-empty-dotnet21
 
   awsjava8-coldstart:
     <<: *coldstart-param
@@ -66,9 +66,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-java-${self:provider.stage}-aws-cold-empty-java8
-              - aws-empty-test-functions-java-${self:provider.stage}-aws-cold-256-empty-java8
-              - aws-empty-test-functions-java-${self:provider.stage}-aws-cold-512-empty-java8
+              - aws-test-java-${self:provider.stage}-aws-cold-empty-java8
+              - aws-test-java-${self:provider.stage}-aws-cold-256-empty-java8
+              - aws-test-java-${self:provider.stage}-aws-cold-512-empty-java8
 
   awsjava11-coldstart:
     <<: *coldstart-param
@@ -80,9 +80,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-java11-${self:provider.stage}-aws-cold-empty-java11
-              - aws-empty-test-functions-java11-${self:provider.stage}-aws-cold-256-empty-java11
-              - aws-empty-test-functions-java11-${self:provider.stage}-aws-cold-512-empty-java11              
+              - aws-test-java11-${self:provider.stage}-aws-cold-empty-java11
+              - aws-test-java11-${self:provider.stage}-aws-cold-256-empty-java11
+              - aws-test-java11-${self:provider.stage}-aws-cold-512-empty-java11              
 
   awsnodejs12x-coldstart:
     <<: *coldstart-param
@@ -94,9 +94,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-empty-nodejs12x
-              - aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs12x
-              - aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs12x
+              - aws-test-nodejs-${self:provider.stage}-aws-cold-empty-nodejs12x
+              - aws-test-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs12x
+              - aws-test-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs12x
 
   awsnodejs10x-coldstart:
     <<: *coldstart-param
@@ -108,9 +108,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-empty-nodejs10x
-              - aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs10x
-              - aws-empty-test-functions-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs10x
+              - aws-test-nodejs-${self:provider.stage}-aws-cold-empty-nodejs10x
+              - aws-test-nodejs-${self:provider.stage}-aws-cold-256-empty-nodejs10x
+              - aws-test-nodejs-${self:provider.stage}-aws-cold-512-empty-nodejs10x
   
   awspython36-coldstart:
     <<: *coldstart-param
@@ -122,9 +122,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-python-${self:provider.stage}-aws-cold-empty-python36
-              - aws-empty-test-functions-python-${self:provider.stage}-aws-cold-256-empty-python36
-              - aws-empty-test-functions-python-${self:provider.stage}-aws-cold-512-empty-python36
+              - aws-test-python-${self:provider.stage}-aws-cold-empty-python36
+              - aws-test-python-${self:provider.stage}-aws-cold-256-empty-python36
+              - aws-test-python-${self:provider.stage}-aws-cold-512-empty-python36
 
   awspython38-coldstart:
     <<: *coldstart-param
@@ -136,9 +136,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-python-${self:provider.stage}-aws-cold-empty-python38
-              - aws-empty-test-functions-python-${self:provider.stage}-aws-cold-256-empty-python38
-              - aws-empty-test-functions-python-${self:provider.stage}-aws-cold-512-empty-python38
+              - aws-test-python-${self:provider.stage}-aws-cold-empty-python38
+              - aws-test-python-${self:provider.stage}-aws-cold-256-empty-python38
+              - aws-test-python-${self:provider.stage}-aws-cold-512-empty-python38
 
   ruby25-coldstart:
     <<: *coldstart-param
@@ -150,9 +150,9 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-empty-ruby25
-              - aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-256-empty-ruby25
-              - aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-512-empty-ruby25
+              - aws-test-ruby-${self:provider.stage}-aws-cold-empty-ruby25
+              - aws-test-ruby-${self:provider.stage}-aws-cold-256-empty-ruby25
+              - aws-test-ruby-${self:provider.stage}-aws-cold-512-empty-ruby25
 
   ruby27-coldstart:
     <<: *coldstart-param
@@ -164,6 +164,6 @@ functions:
           input:
             invokeCount: ${self:custom.coldStartBatchSize}
             targetFunctionName: 
-              - aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-empty-ruby27
-              - aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-256-empty-ruby27
-              - aws-empty-test-functions-ruby-${self:provider.stage}-aws-cold-512-empty-ruby27              
+              - aws-test-ruby-${self:provider.stage}-aws-cold-empty-ruby27
+              - aws-test-ruby-${self:provider.stage}-aws-cold-256-empty-ruby27
+              - aws-test-ruby-${self:provider.stage}-aws-cold-512-empty-ruby27              

--- a/aws-test/aws-service-dotnetcore2/serverless.yml
+++ b/aws-test/aws-service-dotnetcore2/serverless.yml
@@ -1,6 +1,6 @@
 # Config file for aws empty-test functions 
 #
-service: aws-empty-test-functions-dotnet
+service: aws-test-dotnet
 
 provider:
   name: aws

--- a/aws-test/aws-service-go/serverless.yml
+++ b/aws-test/aws-service-go/serverless.yml
@@ -1,6 +1,6 @@
 # Config file for aws empty-test functions
 #
-service: aws-empty-test-functions-go
+service: aws-test-go
 
 provider:
   name: aws

--- a/aws-test/aws-service-java/serverless.yml
+++ b/aws-test/aws-service-java/serverless.yml
@@ -1,6 +1,6 @@
 # Config file for aws empty-test functions
 #
-service: aws-empty-test-functions-java
+service: aws-test-java
 
 provider:
   name: aws

--- a/aws-test/aws-service-java11/serverless.yml
+++ b/aws-test/aws-service-java11/serverless.yml
@@ -1,6 +1,6 @@
 # Config file for aws empty-test functions
 #
-service: aws-empty-test-functions-java11
+service: aws-test-java11
 
 provider:
   name: aws

--- a/aws-test/aws-service-nodejs/serverless.yml
+++ b/aws-test/aws-service-nodejs/serverless.yml
@@ -1,6 +1,6 @@
 # Config file for aws empty-test functions 
 #
-service: aws-empty-test-functions-nodejs
+service: aws-test-nodejs
 
 provider:
   name: aws

--- a/aws-test/aws-service-python/serverless.yml
+++ b/aws-test/aws-service-python/serverless.yml
@@ -1,6 +1,6 @@
 # Config file for aws empty-test functions 
 #
-service: aws-empty-test-functions-python
+service: aws-test-python
 
 provider:
   name: aws

--- a/aws-test/aws-service-ruby/serverless.yml
+++ b/aws-test/aws-service-ruby/serverless.yml
@@ -1,7 +1,7 @@
 
 # Config file for aws empty-test functions - ruby
 #
-service: aws-empty-test-functions-ruby
+service: aws-test-ruby
 
 provider:
   name: aws


### PR DESCRIPTION
Function names generated by serverless framework (generated from serverless.yml via the servicename+functionname) were breaching the 64 char limit.